### PR TITLE
Fixed multithreading problem related to dates

### DIFF
--- a/src/main/java/io/tenmax/cqlkit/RowUtils.java
+++ b/src/main/java/io/tenmax/cqlkit/RowUtils.java
@@ -113,7 +113,7 @@ public class RowUtils {
         });
         return array;
     }
-    
+
     private static String toDateString(Date date) {
         /* protect against multithreaded access of static dateFormat */
         synchronized ( RowUtils.class ) {

--- a/src/main/java/io/tenmax/cqlkit/RowUtils.java
+++ b/src/main/java/io/tenmax/cqlkit/RowUtils.java
@@ -113,8 +113,11 @@ public class RowUtils {
         });
         return array;
     }
-
+    
     private static String toDateString(Date date) {
-        return date != null ? dateFormat.format(date) : null;
+        /* protect against multithreaded access of static dateFormat */
+        synchronized ( RowUtils.class ) {
+            return date != null ? dateFormat.format(date) : null;
+        }
     }
 }


### PR DESCRIPTION
When executing this tool, I was constantly getting a `java.lang.ArrayIndexOutOfBoundsException`. After a little debugging, I figured out that the cause of the problem was using the `SimpleDateFormat` instance statically form multiple different threads.

This synchronises the use of the variable and avoids this issue.